### PR TITLE
Add metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ else()
     message(STATUS "Found xtensor: ${xtensor_INCLUDE_DIRS}/xtensor")
 endif()
 
+find_package(nlohmann_json 3.2.0 REQUIRED)
 
 # Optional dependencies
 # =====================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ message(STATUS "Building zarray v${${PROJECT_NAME}_VERSION}")
 # Dependencies
 # ============
 
-set(xtensor_REQUIRED_VERSION 0.21.9)
+set(xtensor_REQUIRED_VERSION 0.23.0)
 if(TARGET xtensor)
     set(xtensor_VERSION
         ${XTENSOR_VERSION_MAJOR}.${XTENSOR_VERSION_MINOR}.${XTENSOR_VERSION_PATCH})

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake
-  - xtensor=0.22.0
-  - xtensor-io=0.11.0
+  - xtensor=0.23.0
+  - xtensor-io=0.12.0
   - xsimd=7.4.8
   - nlohmann_json=3.2.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,3 +6,4 @@ dependencies:
   - xtensor=0.22.0
   - xtensor-io=0.11.0
   - xsimd=7.4.8
+  - nlohmann_json=3.2.0

--- a/include/zarray/zarray.hpp
+++ b/include/zarray/zarray.hpp
@@ -12,9 +12,10 @@
 
 #include <memory>
 
+#include <nlohmann/json.hpp>
 #include <xtl/xmultimethods.hpp>
+#include <xtensor/xarray.hpp>
 
-#include "xtensor/xarray.hpp"
 #include "zarray_impl.hpp"
 #include "zassign.hpp"
 #include "zfunction.hpp"
@@ -65,7 +66,7 @@ namespace xt
 
         template <class E>
         zarray(xexpression<E>&& e);
-        
+
         template <class E>
         zarray& operator=(const xexpression<E>&);
 
@@ -89,6 +90,8 @@ namespace xt
         void broadcast_shape(shape_type& shape, bool reuse_cache = false) const;
 
         const zchunked_array& as_chunked_array() const;
+
+        const nlohmann::json& attrs() const;
 
     private:
 
@@ -175,7 +178,7 @@ namespace xt
     {
         return semantic_base::operator=(e);
     }
-    
+
     inline void zarray::swap(zarray& rhs)
     {
         std::swap(p_impl, rhs.p_impl);
@@ -246,6 +249,11 @@ namespace xt
     inline zview<const zarray&> make_strided_view(const zarray& z, xstrided_slice_vector& slices)
     {
         return zview<const zarray&>(z, slices);
+    }
+
+    inline const nlohmann::json& zarray::attrs() const
+    {
+        return p_impl->attrs();
     }
 }
 

--- a/include/zarray/zarray.hpp
+++ b/include/zarray/zarray.hpp
@@ -91,7 +91,8 @@ namespace xt
 
         const zchunked_array& as_chunked_array() const;
 
-        const nlohmann::json& attrs() const;
+        const nlohmann::json& get_metadata() const;
+        void set_metadata(const nlohmann::json& metadata);
 
     private:
 
@@ -246,14 +247,19 @@ namespace xt
         return dynamic_cast<const zchunked_array&>(*(p_impl.get()));
     }
 
+    inline const nlohmann::json& zarray::get_metadata() const
+    {
+        return p_impl->get_metadata();
+    }
+
+    inline void zarray::set_metadata(const nlohmann::json& metadata)
+    {
+        return p_impl->set_metadata(metadata);
+    }
+
     inline zview<const zarray&> make_strided_view(const zarray& z, xstrided_slice_vector& slices)
     {
         return zview<const zarray&>(z, slices);
-    }
-
-    inline const nlohmann::json& zarray::attrs() const
-    {
-        return p_impl->attrs();
     }
 }
 

--- a/include/zarray/zarray_impl.hpp
+++ b/include/zarray/zarray_impl.hpp
@@ -22,106 +22,81 @@ namespace xt
 {
     const std::string endianness_string = (xtl::endianness() == xtl::endian::little_endian) ? "<" : ">";
 
-    template <class T, class = void>
-    struct has_attrs : std::false_type
-    {
-    };
-
     template <class T>
-    struct has_attrs<T, void_t<decltype(std::declval<T>().attrs())>>
-        : std::true_type
-    {
-    };
-
-    template <class T>
-    typename std::enable_if<has_attrs<T>::value, const nlohmann::json&>::type
-    get_attrs(T& t, const nlohmann::json& attrs)
-    {
-        return t.attrs();
-    }
-
-    template <class T>
-    typename std::enable_if<!has_attrs<T>::value, const nlohmann::json&>::type
-    get_attrs(T& t, const nlohmann::json& attrs)
-    {
-        return attrs;
-    }
-
-    template <class T>
-    inline void set_data_type(nlohmann::json& attrs)
+    inline void set_data_type(nlohmann::json& metadata)
     {
     }
 
     template <>
-    inline void set_data_type<bool>(nlohmann::json& attrs)
+    inline void set_data_type<bool>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = "bool";
+        metadata["data_type"] = "bool";
     }
 
     template <>
-    inline void set_data_type<uint8_t>(nlohmann::json& attrs)
+    inline void set_data_type<uint8_t>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = "u1";
+        metadata["data_type"] = "u1";
     }
 
     template <>
-    inline void set_data_type<int8_t>(nlohmann::json& attrs)
+    inline void set_data_type<int8_t>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = "i1";
+        metadata["data_type"] = "i1";
     }
 
     template <>
-    inline void set_data_type<int16_t>(nlohmann::json& attrs)
+    inline void set_data_type<int16_t>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "i2";
+        metadata["data_type"] = endianness_string + "i2";
     }
 
     template <>
-    inline void set_data_type<uint16_t>(nlohmann::json& attrs)
+    inline void set_data_type<uint16_t>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "u2";
+        metadata["data_type"] = endianness_string + "u2";
     }
 
     template <>
-    inline void set_data_type<int32_t>(nlohmann::json& attrs)
+    inline void set_data_type<int32_t>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "i4";
+        metadata["data_type"] = endianness_string + "i4";
     }
 
     template <>
-    inline void set_data_type<uint32_t>(nlohmann::json& attrs)
+    inline void set_data_type<uint32_t>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "u4";
+        metadata["data_type"] = endianness_string + "u4";
     }
 
     template <>
-    inline void set_data_type<int64_t>(nlohmann::json& attrs)
+    inline void set_data_type<int64_t>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "i8";
+        metadata["data_type"] = endianness_string + "i8";
     }
 
     template <>
-    inline void set_data_type<uint64_t>(nlohmann::json& attrs)
+    inline void set_data_type<uint64_t>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "u8";
+        metadata["data_type"] = endianness_string + "u8";
     }
 
     template <>
-    inline void set_data_type<xtl::half_float>(nlohmann::json& attrs)
+    inline void set_data_type<xtl::half_float>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "f2";
+        metadata["data_type"] = endianness_string + "f2";
     }
 
     template <>
-    inline void set_data_type<float>(nlohmann::json& attrs)
+    inline void set_data_type<float>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "f4";
+        metadata["data_type"] = endianness_string + "f4";
     }
 
     template <>
-    inline void set_data_type<double>(nlohmann::json& attrs)
+    inline void set_data_type<double>(nlohmann::json& metadata)
     {
-        attrs["data_type"] = endianness_string + "f8";
+        metadata["data_type"] = endianness_string + "f8";
     }
 
     /*************************
@@ -174,7 +149,8 @@ namespace xt
         virtual std::size_t get_offset() const = 0;
         virtual layout_type layout() const = 0;
 
-        virtual const nlohmann::json& attrs() const = 0;
+        virtual const nlohmann::json& get_metadata() const = 0;
+        virtual void set_metadata(const nlohmann::json& metadata) = 0;
         virtual std::size_t dimension() const = 0;
         virtual const shape_type& shape() const = 0;
         virtual void resize(const shape_type& shape) = 0;
@@ -242,7 +218,8 @@ namespace xt
         std::size_t get_offset() const override;
         layout_type layout() const override;
 
-        const nlohmann::json& attrs() const override;
+        const nlohmann::json& get_metadata() const override;
+        void set_metadata(const nlohmann::json& metadata) override;
         std::size_t dimension() const override;
         const shape_type& shape() const override;
         void resize(const shape_type&) override;
@@ -258,7 +235,7 @@ namespace xt
         CTE m_expression;
         mutable xarray<value_type> m_cache;
         mutable bool m_cache_initialized;
-        nlohmann::json m_attrs;
+        nlohmann::json m_metadata;
     };
 
     /*******************
@@ -291,7 +268,8 @@ namespace xt
         std::size_t get_offset() const override;
         layout_type layout() const override;
 
-        const nlohmann::json& attrs() const override;
+        const nlohmann::json& get_metadata() const override;
+        void set_metadata(const nlohmann::json& metadata) override;
         std::size_t dimension() const override;
         const shape_type& shape() const override;
         void resize(const shape_type&) override;
@@ -304,7 +282,7 @@ namespace xt
 
         CTE m_expression;
         xarray<value_type> m_array;
-        nlohmann::json m_attrs;
+        nlohmann::json m_metadata;
     };
 
     /******************
@@ -335,7 +313,8 @@ namespace xt
         std::size_t get_offset() const override;
         layout_type layout() const override;
 
-        const nlohmann::json& attrs() const override;
+        const nlohmann::json& get_metadata() const override;
+        void set_metadata(const nlohmann::json& metadata) override;
         std::size_t dimension() const override;
         const shape_type& shape() const override;
         void resize(const shape_type&) override;
@@ -347,7 +326,7 @@ namespace xt
         zarray_wrapper(const zarray_wrapper&) = default;
 
         CTE m_array;
-        nlohmann::json m_attrs;
+        nlohmann::json m_metadata;
     };
 
     /********************
@@ -389,7 +368,8 @@ namespace xt
         std::size_t get_offset() const override;
         layout_type layout() const override;
 
-        const nlohmann::json& attrs() const override;
+        const nlohmann::json& get_metadata() const override;
+        void set_metadata(const nlohmann::json& metadata) override;
         std::size_t dimension() const override;
         const shape_type& shape() const override;
         void resize(const shape_type& shape) override;
@@ -411,7 +391,7 @@ namespace xt
         mutable dynamic_shape<std::ptrdiff_t> m_strides;
         mutable bool m_strides_initialized;
 
-        nlohmann::json m_attrs;
+        nlohmann::json m_metadata;
 
     };
 
@@ -427,7 +407,7 @@ namespace xt
         , m_cache()
         , m_cache_initialized(false)
     {
-        set_data_type<value_type>(m_attrs);
+        set_data_type<value_type>(m_metadata);
     }
 
     template <class CTE>
@@ -472,9 +452,15 @@ namespace xt
     }
 
     template <class CTE>
-    inline auto zexpression_wrapper<CTE>::attrs() const -> const nlohmann::json&
+    inline auto zexpression_wrapper<CTE>::get_metadata() const -> const nlohmann::json&
     {
-        return m_attrs;
+        return m_metadata;
+    }
+
+    template <class CTE>
+    inline void zexpression_wrapper<CTE>::set_metadata(const nlohmann::json& metadata)
+    {
+        m_metadata = metadata;
     }
 
     template <class CTE>
@@ -529,7 +515,7 @@ namespace xt
         , m_expression(std::forward<E>(e))
         , m_array(m_expression())
     {
-        set_data_type<value_type>(m_attrs);
+        set_data_type<value_type>(m_metadata);
     }
 
     template <class CTE>
@@ -569,9 +555,15 @@ namespace xt
     }
 
     template <class CTE>
-    inline auto zscalar_wrapper<CTE>::attrs() const -> const nlohmann::json&
+    inline auto zscalar_wrapper<CTE>::get_metadata() const -> const nlohmann::json&
     {
-        return m_attrs;
+        return m_metadata;
+    }
+
+    template <class CTE>
+    inline void zscalar_wrapper<CTE>::set_metadata(const nlohmann::json& metadata)
+    {
+        m_metadata = metadata;
     }
 
     template <class CTE>
@@ -643,7 +635,7 @@ namespace xt
         : base_type()
         , m_array(std::forward<E>(e))
     {
-        set_data_type<value_type>(m_attrs);
+        set_data_type<value_type>(m_metadata);
     }
 
     template <class CTE>
@@ -683,9 +675,15 @@ namespace xt
     }
 
     template <class CTE>
-    inline auto zarray_wrapper<CTE>::attrs() const -> const nlohmann::json&
+    inline auto zarray_wrapper<CTE>::get_metadata() const -> const nlohmann::json&
     {
-        return m_attrs;
+        return m_metadata;
+    }
+
+    template <class CTE>
+    inline void zarray_wrapper<CTE>::set_metadata(const nlohmann::json& metadata)
+    {
+        m_metadata = metadata;
     }
 
     template <class CTE>
@@ -735,7 +733,7 @@ namespace xt
         std::copy(m_chunked_array.chunk_shape().begin(),
                   m_chunked_array.chunk_shape().end(),
                   m_chunk_shape.begin());
-        set_data_type<value_type>(m_attrs);
+        set_data_type<value_type>(m_metadata);
     }
 
     template <class CTE>
@@ -782,9 +780,15 @@ namespace xt
     }
 
     template <class CTE>
-    inline auto zchunked_wrapper<CTE>::attrs() const -> const nlohmann::json&
+    inline auto zchunked_wrapper<CTE>::get_metadata() const -> const nlohmann::json&
     {
-        return get_attrs(m_chunked_array, m_attrs);
+        return m_metadata;
+    }
+
+    template <class CTE>
+    inline void zchunked_wrapper<CTE>::set_metadata(const nlohmann::json& metadata)
+    {
+        m_metadata = metadata;
     }
 
     template <class CTE>
@@ -856,8 +860,8 @@ namespace xt
         {
         };
 
-        template <class CS, class E>
-        struct is_chunked_array<xchunked_array<CS, E>> : std::true_type
+        template <class CS>
+        struct is_chunked_array<xchunked_array<CS>> : std::true_type
         {
         };
 

--- a/test/test_zarray.cpp
+++ b/test/test_zarray.cpp
@@ -19,27 +19,7 @@ namespace xt
     {
         auto a = xarray<T>();
         zarray z(a);
-        EXPECT_EQ(z.attrs()["data_type"], data_type);
-    }
-
-    class xattrs
-    {
-    public:
-        const nlohmann::json& attrs();
-        void set_attrs(const nlohmann::json& attrs);
-
-    private:
-        nlohmann::json m_attrs;
-    };
-
-    inline const nlohmann::json& xattrs::attrs()
-    {
-        return m_attrs;
-    }
-
-    inline void xattrs::set_attrs(const nlohmann::json& attrs)
-    {
-        m_attrs = attrs;
+        EXPECT_EQ(z.get_metadata()["data_type"], data_type);
     }
 
     TEST(zarray, constructor)
@@ -243,7 +223,7 @@ namespace xt
         EXPECT_EQ(a1, a2);
     }
 
-    TEST(zarray, xarray_data_type)
+    TEST(zarray, data_type)
     {
         std::string s = (xtl::endianness() == xtl::endian::little_endian) ? "<" : ">";
         check_xarray_data_type<bool>("bool");
@@ -260,27 +240,16 @@ namespace xt
         check_xarray_data_type<double>(s + "f8");
     }
 
-    TEST(zarray, chunked_array_attrs)
+    TEST(zarray, custom_metadata)
     {
         using shape_type =  zarray::shape_type;
         shape_type shape = {4, 4};
         shape_type chunk_shape = {2, 2};
-        auto a = chunked_array<double, XTENSOR_DEFAULT_LAYOUT, xattrs>(shape, chunk_shape);
-        nlohmann::json attrs;
-        attrs["foo"] = "bar";
-        a.set_attrs(attrs);
+        auto a = chunked_array<double, XTENSOR_DEFAULT_LAYOUT>(shape, chunk_shape);
         zarray z(a);
-        EXPECT_EQ(z.attrs()["foo"], "bar");
-    }
-
-    TEST(zarray, chunked_array_noattrs)
-    {
-        std::string s = (xtl::endianness() == xtl::endian::little_endian) ? "<" : ">";
-        using shape_type =  zarray::shape_type;
-        shape_type shape = {4, 4};
-        shape_type chunk_shape = {2, 2};
-        auto a = chunked_array<double>(shape, chunk_shape);
-        zarray z(a);
-        EXPECT_EQ(z.attrs()["data_type"], s + "f8");
+        nlohmann::json metadata;
+        metadata["foo"] = "bar";
+        z.set_metadata(metadata);
+        EXPECT_EQ(z.get_metadata()["foo"], "bar");
     }
 }


### PR DESCRIPTION
The idea is to have a `data_type` key in the zarray attributes when wrapping an `xarray` (or a scalar or an expression), for well-known types (I have only implemented and tested `uint8_t` and `int8_t` for now). For other types, the `data_type` key wouldn't exist. Should we also include other information in the attributes, like the shape (even though it is also accessible with the `shape()` method) or the item size?
When wrapping a chunked array, we check that it doesn't already have an `attrs` method, because [chunked arrays can be extended](https://github.com/xtensor-stack/xtensor/blob/a07aae2076189935e36ddabe029dcfcdc673cd61/include/xtensor/xchunked_array.hpp#L73-L74) (in particular, [xtensor-zarr does it](https://github.com/xtensor-stack/xtensor-zarr/blob/d5cec3e41b292573b30f220e050bc638ead5c85d/include/xtensor-zarr/xzarr_compressor.hpp#L70)).