### PR TITLE
added failing test

### DIFF
--- a/test/test_zfunction.cpp
+++ b/test/test_zfunction.cpp
@@ -145,5 +145,35 @@ namespace xt
 
         EXPECT_EQ(zres.get_array<double>(), expected);
     }
+
+    TEST(zfunction, math_operator_extended)
+    {
+        EXPECT_EQ(0,1);
+
+        using add_dispatcher_type = zdispatcher_t<detail::plus, 2>;
+        add_dispatcher_type::init();
+
+        xarray<int> a = {{1, 1}, {1, 1}};
+        xarray<int> b = {{2, 2}, {2, 2}};
+        xarray<int> c = {{3, 3}, {3, 3}};
+        xarray<int> d = {{4, 4}, {4, 4}};
+
+        auto res = xarray<int>::from_shape({2, 2});
+
+        zarray za(a);
+        zarray zb(b);
+        zarray zc(c);
+        zarray zd(d);
+        zarray zres(res);
+
+        auto f = ((za+zb) + (zc+zd)) + zd;
+
+        zassign_args args;
+
+        f.assign_to(zres.get_implementation(), args);
+
+        auto expected = xt::eval((a+b) + (c+d) + d);
+        EXPECT_EQ(res, expected);
+    }
 }
 


### PR DESCRIPTION
```c++
TEST(zfunction, math_operator_extended)
{
    using add_dispatcher_type = zdispatcher_t<detail::plus, 2>;
    add_dispatcher_type::init();

    xarray<int> a = {{1, 1}, {1, 1}};
    xarray<int> b = {{2, 2}, {2, 2}};
    xarray<int> c = {{3, 3}, {3, 3}};
    xarray<int> d = {{4, 4}, {4, 4}};

    auto res = xarray<int>::from_shape({2, 2});

    zarray za(a);
    zarray zb(b);
    zarray zc(c);
    zarray zd(d);
    zarray zres(res);

    auto f = ((za+zb) + (zc+zd)) + zd;

    zassign_args args;

    f.assign_to(zres.get_implementation(), args);

    auto expected = xt::eval((a+b) + (c+d) + d);
    EXPECT_EQ(res, expected);
}
 ```

```
Expected equality of these values:
  res
    Which is: { 10, 10, 10, 10 }
  expected
    Which is: { 14, 14, 14, 14 }
```